### PR TITLE
Fix H-03–H-06: Concurrency hardening and error observability

### DIFF
--- a/Source/CaptureAudioPreview.swift
+++ b/Source/CaptureAudioPreview.swift
@@ -270,7 +270,12 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         var count = 0
         queueSync {
             count = numEnqueued - 1
-            assert(count >= 0, "ERROR: Enqueued Counter value error.")
+            // H-05: Preserve invariant in Release builds.
+            // assert() is compiled out in Release, so an underflow would silently wrap
+            // to Int.max and corrupt the counter. Clamp to 0 instead.
+            if count < 0 {
+                count = 0
+            }
             numEnqueued = count
             
             if show {
@@ -289,7 +294,12 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         var count = 0
         queueSync {
             count = numEnqueued + 1
-            assert(count <= kNumberBuffer, "ERROR: Enqueued Counter value error.")
+            // H-05: Preserve invariant in Release builds.
+            // assert() is compiled out in Release, so an overflow would silently wrap
+            // to negative and corrupt the counter. Clamp to kNumberBuffer instead.
+            if count > kNumberBuffer {
+                count = kNumberBuffer
+            }
             numEnqueued = count
             
             if show {

--- a/Source/CaptureAudioPreview.swift
+++ b/Source/CaptureAudioPreview.swift
@@ -271,8 +271,8 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         queueSync {
             count = numEnqueued - 1
             // H-05: Preserve invariant in Release builds.
-            // assert() is compiled out in Release, so an underflow would silently wrap
-            // to Int.max and corrupt the counter. Clamp to 0 instead.
+            // assert() is compiled out in Release, so an unexpected extra dequeue
+            // can drive the counter negative. Clamp to 0 instead.
             if count < 0 {
                 count = 0
                 print("WARNING: numEnqueued underflow clamped (counter imbalance?)")
@@ -296,8 +296,8 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         queueSync {
             count = numEnqueued + 1
             // H-05: Preserve invariant in Release builds.
-            // assert() is compiled out in Release, so an overflow would silently wrap
-            // to negative and corrupt the counter. Clamp to kNumberBuffer instead.
+            // assert() is compiled out in Release, so an unexpected extra enqueue
+            // can drive the counter above kNumberBuffer. Clamp instead.
             if count > kNumberBuffer {
                 count = kNumberBuffer
                 print("WARNING: numEnqueued overflow clamped at kNumberBuffer (counter imbalance?)")

--- a/Source/CaptureAudioPreview.swift
+++ b/Source/CaptureAudioPreview.swift
@@ -261,7 +261,7 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         return nil
     }
     
-    /// Increment queued buffer count
+    /// Decrement queued buffer count
     ///
     /// - Parameter show: debug dump the count
     /// - Returns: count of queued buffer
@@ -275,6 +275,7 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
             // to Int.max and corrupt the counter. Clamp to 0 instead.
             if count < 0 {
                 count = 0
+                print("WARNING: numEnqueued underflow clamped (counter imbalance?)")
             }
             numEnqueued = count
             
@@ -285,7 +286,7 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         return count
     }
     
-    /// Decrement queued buffer count
+    /// Increment queued buffer count
     ///
     /// - Parameter show: debug dump the count
     /// - Returns: count of queued buffer
@@ -299,6 +300,7 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
             // to negative and corrupt the counter. Clamp to kNumberBuffer instead.
             if count > kNumberBuffer {
                 count = kNumberBuffer
+                print("WARNING: numEnqueued overflow clamped at kNumberBuffer (counter imbalance?)")
             }
             numEnqueued = count
             

--- a/Source/CaptureManager.swift
+++ b/Source/CaptureManager.swift
@@ -128,7 +128,7 @@ private final class BoundedWorkQueue: @unchecked Sendable {
 
 private final class WeakParentViewBox: @unchecked Sendable {
     weak var view: NSView?
-
+    
     init(view: NSView?) {
         self.view = view
     }
@@ -137,7 +137,7 @@ private final class WeakParentViewBox: @unchecked Sendable {
 private final class LockedWeakReferenceBox<Value: AnyObject>: @unchecked Sendable {
     private let lock = UnfairLockBox()
     private weak var storage: Value?
-
+    
     var value: Value? {
         get { lock.withLock { storage } }
         set { lock.withLock { storage = newValue } }
@@ -147,13 +147,13 @@ private final class LockedWeakReferenceBox<Value: AnyObject>: @unchecked Sendabl
 private final class LockedOptionalValueBox<Value>: @unchecked Sendable {
     private let lock = UnfairLockBox()
     private var storage: Value?
-
+    
     func withLock<T>(_ body: (inout Value?) -> T) -> T {
         lock.withLock {
             body(&storage)
         }
     }
-
+    
     var value: Value? {
         get { withLock { $0 } }
         set { withLock { $0 = newValue } }
@@ -163,7 +163,7 @@ private final class LockedOptionalValueBox<Value>: @unchecked Sendable {
 private struct AudioPreviewDisposeFailure: LocalizedError {
     let stopError: NSError
     let disposeError: NSError
-
+    
     var errorDescription: String? {
         "Audio preview teardown failed."
     }
@@ -1262,7 +1262,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     private func clearInputAncillaryPacketHandler(from device: DLABDevice) {
         device.inputAncillaryPacketHandler = nil
     }
-
+    
     private func currentInputAncillaryPacketHandlerGeneration() -> UInt64 {
         inputAncillaryPacketHandlerLock.withLock { _ in inputAncillaryPacketHandlerGeneration }
     }

--- a/Source/CaptureManager.swift
+++ b/Source/CaptureManager.swift
@@ -848,9 +848,10 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 if let vSetting = vSetting {
                     // Enable Video Preview
                     if let parentView = parentView {
-                        Task { @MainActor in
+                        Task { @MainActor [weak self] in
+                            guard let self = self else { return }
                             do {
-                                try attachInputScreenPreview(to: parentView) // @MainActor
+                                try self.attachInputScreenPreview(to: parentView) // @MainActor
                             } catch {
                                 self.printVerbose("ERROR: captureStartAsync - attachInputScreenPreview failed: \(error.localizedDescription)")
                                 self.previewError = error

--- a/Source/CaptureManager.swift
+++ b/Source/CaptureManager.swift
@@ -220,6 +220,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         var lastRecordedMoviePostProcessError: Error? = nil
         var stopError: (any Error)? = nil
         var audioPreviewError: (any Error)? = nil
+        var previewError: (any Error)? = nil
         var currentDevice: DLABDevice? = nil
         var audioCaptureEnabled: Bool = false
         var videoCaptureEnabled: Bool = false
@@ -569,6 +570,19 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         withRuntimeState { $0.audioPreviewError = nil }
     }
     
+    /// Last video preview failure (attachInputScreenPreview), if any.
+    /// Overwritten on each new failure; not cleared automatically.
+    /// Use ``clearPreviewError()`` to reset after handling.
+    public private(set) var previewError: (any Error)? {
+        get { runtimeStateValue(\.previewError) }
+        set { withRuntimeState { $0.previewError = newValue } }
+    }
+    
+    /// Clear the last video preview error.
+    public func clearPreviewError() {
+        withRuntimeState { $0.previewError = nil }
+    }
+    
     /// Optional callback for non-fatal `CaptureWriter` diagnostics during fallback cleanup.
     public var captureWriterDiagnosticHandler: (@Sendable (CaptureWriterDiagnostic) -> Void)? = nil
     
@@ -835,7 +849,12 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     // Enable Video Preview
                     if let parentView = parentView {
                         Task { @MainActor in
-                            try attachInputScreenPreview(to: parentView) // @MainActor
+                            do {
+                                try attachInputScreenPreview(to: parentView) // @MainActor
+                            } catch {
+                                self.printVerbose("ERROR: captureStartAsync - attachInputScreenPreview failed: \(error.localizedDescription)")
+                                self.previewError = error
+                            }
                         }
                     }
                     if let videoPreview = videoPreview {

--- a/Source/CaptureVideoPreview.swift
+++ b/Source/CaptureVideoPreview.swift
@@ -670,7 +670,7 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
                 cache.enqueuePending = true
                 Task { @MainActor [weak self] in
                     guard let self = self else {
-                        self?.cache.enqueuePending = false
+                        // Self deallocated; cache goes with it, no reset needed.
                         return
                     }
                     _ = self.enqueue(targetTimestamp, expiredTimestamp)

--- a/Source/CaptureVideoPreview.swift
+++ b/Source/CaptureVideoPreview.swift
@@ -646,10 +646,7 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
                 guard let self = self else { return kCVReturnError }
                 
                 if cache.donotEnqueue {
-                    Task { @MainActor [weak self] in
-                        guard let self = self else { return }
-                        self.printVerbose("NOTICE: DisplayLink is suspended. Ignore enqueue request (\(#function))")
-                    }
+                    self.printVerbose("NOTICE: DisplayLink is suspended. Ignore enqueue request (\(#function))")
                     return kCVReturnError
                 }
                 

--- a/Source/CaptureVideoPreview.swift
+++ b/Source/CaptureVideoPreview.swift
@@ -195,6 +195,9 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
         
         cache.prepared = false
         cache.donotEnqueue = true
+        // H-04: belt-and-suspenders reset; donotEnqueue already short-circuits the
+        // callback, but keep enqueuePending consistent for any future reference.
+        cache.enqueuePending = false
         
         if let caDisplayLink = cache.caDisplayLink, #available(macOS 14.0, *) {
             caDisplayLink.invalidate()
@@ -673,6 +676,7 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
                         // Self deallocated; cache goes with it, no reset needed.
                         return
                     }
+                    // Intentionally discard Bool: DisplayLink path drops per-frame failures.
                     _ = self.enqueue(targetTimestamp, expiredTimestamp)
                     self.cache.enqueuePending = false
                 }

--- a/Source/CaptureVideoPreview.swift
+++ b/Source/CaptureVideoPreview.swift
@@ -53,6 +53,13 @@ fileprivate final class CaptureVideoPreviewCache: @unchecked Sendable {
         get { withLock { displayLinkValue } }
         set { withLock { displayLinkValue = newValue } }
     }
+    
+    // H-04: Guard to limit concurrent enqueue Tasks to max 1
+    private var enqueuePendingValue: Bool = false
+    var enqueuePending: Bool {
+        get { withLock { enqueuePendingValue } }
+        set { withLock { enqueuePendingValue = newValue } }
+    }
 }
 
 @MainActor
@@ -636,10 +643,16 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
                 guard let self = self else { return kCVReturnError }
                 
                 if cache.donotEnqueue {
-                    Task { @MainActor in
-                        printVerbose("NOTICE: DisplayLink is suspended. Ignore enqueue request (\(#function))")
+                    Task { @MainActor [weak self] in
+                        guard let self = self else { return }
+                        self.printVerbose("NOTICE: DisplayLink is suspended. Ignore enqueue request (\(#function))")
                     }
                     return kCVReturnError
+                }
+                
+                // H-04: Limit concurrent enqueue Tasks to max 1 to avoid unbounded generation
+                if cache.enqueuePending {
+                    return kCVReturnSuccess
                 }
                 
                 guard
@@ -653,9 +666,15 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
                 let nextVSync = lastVSync + refreshInterval // next vsync (next frame)
                 let expiredTimestamp = nextVSync + refreshInterval // next frame expired
                 
-                // Schedule enqueue on MainActor
-                Task { @MainActor in
-                    enqueue(targetTimestamp, expiredTimestamp)
+                // Schedule enqueue on MainActor (max 1 in-flight at a time)
+                cache.enqueuePending = true
+                Task { @MainActor [weak self] in
+                    guard let self = self else {
+                        self?.cache.enqueuePending = false
+                        return
+                    }
+                    _ = self.enqueue(targetTimestamp, expiredTimestamp)
+                    self.cache.enqueuePending = false
                 }
                 return kCVReturnSuccess
             }

--- a/Source/CaptureWriter.swift
+++ b/Source/CaptureWriter.swift
@@ -422,10 +422,10 @@ actor CaptureWriter {
             // - internalError after close: error from stopRecording() itself
             //   (e.g. finishWritingTimedOut, unexpectedErrorWhileClosingSession).
             if let priorWriteError = priorWriteError {
-                diagnosticHandler?(.reopenCloseFailed(reason: priorWriteError.localizedDescription))
+                diagnosticHandler?(.reopenCloseFailed(reason: "prior write error: \(priorWriteError.localizedDescription)"))
             }
             if let closeError = internalError {
-                diagnosticHandler?(.reopenCloseFailed(reason: closeError.localizedDescription))
+                diagnosticHandler?(.reopenCloseFailed(reason: "closeSession error: \(closeError.localizedDescription)"))
             }
         }
         

--- a/Source/CaptureWriter.swift
+++ b/Source/CaptureWriter.swift
@@ -411,10 +411,21 @@ actor CaptureWriter {
         
         // H-06: If a previous session is still open, close it first to recover writer state.
         if isRecording {
+            // Capture any in-flight write error from the previous session BEFORE
+            // closeSession() resets internalError at its start.
+            let priorWriteError = internalError
             await closeSession()
-            // H-06: Surface the close error from the previous session via diagnostic.
-            if let priorError = internalError {
-                diagnosticHandler?(.reopenCloseFailed(reason: priorError.localizedDescription))
+            // H-06: Surface errors from the previous session via diagnostic.
+            // - priorWriteError: append-time error that was stored in internalError
+            //   (e.g. AVAssetWriterInput.append returned false). Would otherwise be
+            //   silently lost if closeSession() succeeds.
+            // - internalError after close: error from stopRecording() itself
+            //   (e.g. finishWritingTimedOut, unexpectedErrorWhileClosingSession).
+            if let priorWriteError = priorWriteError {
+                diagnosticHandler?(.reopenCloseFailed(reason: priorWriteError.localizedDescription))
+            }
+            if let closeError = internalError {
+                diagnosticHandler?(.reopenCloseFailed(reason: closeError.localizedDescription))
             }
         }
         

--- a/Source/CaptureWriter.swift
+++ b/Source/CaptureWriter.swift
@@ -66,6 +66,7 @@ enum CaptureWriterError: Swift.Error, LocalizedError {
 public enum CaptureWriterDiagnostic: Sendable, Equatable {
     case deinitWhileRecording
     case finishWritingTimedOut(timeoutSeconds: Double)
+    case reopenCloseFailed(reason: String)
 }
 
 /// Thread safe backing store - works with deinit and nonisolated func.
@@ -408,8 +409,13 @@ actor CaptureWriter {
         openSessionStartedAt = CFAbsoluteTimeGetCurrent()
         loggedFirstVideoAppend = false
         
+        // H-06: If a previous session is still open, close it first to recover writer state.
         if isRecording {
             await closeSession()
+            // H-06: Surface the close error from the previous session via diagnostic.
+            if let priorError = internalError {
+                diagnosticHandler?(.reopenCloseFailed(reason: priorError.localizedDescription))
+            }
         }
         
         if movieURL == nil {


### PR DESCRIPTION
## Summary

Consolidates fixes for backlog issues H-03 through H-06, each reviewed and updated before merging into this branch.

---

## H-03 — @MainActor Task error observation (`CaptureManager`)

**Problem:** `attachInputScreenPreview` was called bare inside `Task { @MainActor in }` with `try`, so any thrown error was silently discarded.

**Fix:**
- Wrapped the call in `do-catch`; errors are stored in the new `public private(set) var previewError`
- Added `clearPreviewError()` for caller-side reset
- Used `[weak self]` capture consistent with existing patterns in the same file

---

## H-04 — CVDisplayLink unbounded Task generation (`CaptureVideoPreview`)

**Problem:** The CVDisplayLink callback spawned a new `Task { @MainActor in }` every vsync tick regardless of whether the previous one had completed, potentially queuing unbounded Tasks.

**Fix:**
- Added `enqueuePending: Bool` flag (lock-protected) to `CaptureVideoPreviewCache`
- Callback skips Task creation when a Task is already in-flight; flag is reset after the Task body runs
- `deinitHelper` resets `enqueuePending = false` alongside `donotEnqueue`
- `[weak self]` added to both Task closures in the callback; discarded `Bool` return from `enqueue()` documented

---

## H-05 — Audio buffer counter invariant in Release builds (`CaptureAudioPreview`)

**Problem:** `assert()` is compiled out in Release builds, so an imbalanced enqueue/dequeue could silently wrap `numEnqueued` to `Int.max` or negative, corrupting the counter.

**Fix:**
- Replaced `assert` with explicit clamp (`count < 0 → 0`, `count > kNumberBuffer → kNumberBuffer`)
- Added `print(WARNING:)` log when clamp is triggered, preserving observability in all build configurations
- Fixed pre-existing doc comment inversion: `numEnqueuedCountDec` was labeled "Increment" and `numEnqueuedCountInc` was labeled "Decrement"

---

## H-06 — CaptureWriter reopen error diagnostic (`CaptureWriter`)

**Problem:** When `openSession()` was called while `isRecording == true`, it called `closeSession()` to recover — but `closeSession()` resets `internalError = nil` at its start, silently discarding any append-time write error from the previous session.

**Fix:**
- Added `CaptureWriterDiagnostic.reopenCloseFailed(reason: String)`
- Snapshot `internalError` before `closeSession()` to preserve any prior write error
- Emit diagnostic for both the prior write error (if any) and any error from `closeSession()` itself

---

## Files changed

| File | Issues |
|------|--------|
| `Source/CaptureManager.swift` | H-03 |
| `Source/CaptureVideoPreview.swift` | H-04 |
| `Source/CaptureAudioPreview.swift` | H-05 |
| `Source/CaptureWriter.swift` | H-06 |

Build and Analyze pass on all 4 individual branches and on this consolidated branch.